### PR TITLE
chore: rename methods and add fork simulation

### DIFF
--- a/src/providers/blockchain/JsonBlockchainClient.spec.ts
+++ b/src/providers/blockchain/JsonBlockchainClient.spec.ts
@@ -27,27 +27,26 @@ describe('JsonFileBlockchain', () => {
   });
 
   it('should serve blocks in json file as blockchain data', async () => {
-    expect(await blockchainClient.getBlockByHeight(0)).toStrictEqual(
+    expect(await blockchainClient.getBlocksAtHeight(0)).toStrictEqual([
       jsonBlocks[0],
-    );
-    expect(await blockchainClient.getBlockByHeight(100)).toStrictEqual(
+    ]);
+    expect(await blockchainClient.getBlocksAtHeight(100)).toStrictEqual([
       jsonBlocks[100],
-    );
-    expect(await blockchainClient.getBlockByHeight(199)).toStrictEqual(
-      jsonBlocks[199],
-    );
+    ]);
+    expect(await blockchainClient.getBlocksAtHeight(199)).toStrictEqual([
+      jsonBlocks[200], // offset by 1 due to fork (2 blocks) at height 198
+    ]);
   });
 
   it('should get chain height', async () => {
-    const height = await blockchainClient.getChainHeight();
-    expect(height).toStrictEqual(jsonBlocks.length);
+    const height = await blockchainClient.getBlockCount();
     expect(height).toStrictEqual(200);
   });
 
   it('should get block by height', async () => {
-    expect(await blockchainClient.getBlockByHeight(0)).toStrictEqual(
+    expect(await blockchainClient.getBlocksAtHeight(0)).toStrictEqual([
       jsonBlocks[0],
-    );
+    ]);
   });
 
   it('should get block by hash', async () => {
@@ -56,5 +55,18 @@ describe('JsonFileBlockchain', () => {
         'd744db74fb70ed42767ae028a129365fb4d7de54ba1b6575fb047490554f8a7b',
       ),
     ).toStrictEqual(jsonBlocks[0]);
+  });
+
+  it('should return forked blocks at height 198', async () => {
+    expect(await blockchainClient.getBlocksAtHeight(198)).toStrictEqual([
+      {
+        hash: 'ef61aaf7f6f742ed825922b10ec504ee74cfcb9c71037706dd8a87c627f541f9',
+        ...jsonBlocks[198],
+      },
+      {
+        hash: 'ef61aaf7f6f742ed825922b10ec504ee74cfcb9c71037706dd8a8FORKEDBLOCK',
+        ...jsonBlocks[199],
+      },
+    ]);
   });
 });

--- a/src/providers/blockchain/JsonBlockchainClient.ts
+++ b/src/providers/blockchain/JsonBlockchainClient.ts
@@ -23,21 +23,18 @@ export class JsonBlockchainClient
 
   constructor(@Inject(JSON_BLOCKS) private readonly path: string) {}
 
-  async getChainHeight(): Promise<number> {
-    return this.simulateAsync(() => {
-      return this.blocks.length;
-    });
+  async getBlockCount(): Promise<number> {
+    return this.delay(() => this.blocks[this.blocks.length - 1].height + 1);
   }
 
-  async getBlockByHeight(height: number): Promise<Block | undefined> {
-    return this.simulateAsync(() => {
-      const blocks = this.blocks.filter((block) => height === block.height);
-      return blocks[0];
-    });
+  async getBlocksAtHeight(height: number): Promise<Block[] | undefined> {
+    return this.delay(() =>
+      this.blocks.filter((block) => height === block.height),
+    );
   }
 
   async getBlockByHash(hash: string): Promise<Block | undefined> {
-    return this.simulateAsync(() => {
+    return this.delay(() => {
       const blocks = this.blocks.filter((block) => hash === block.hash);
       return blocks[0];
     });
@@ -50,6 +47,7 @@ export class JsonBlockchainClient
   onApplicationBootstrap(): void {
     this.blocks = JSON.parse(readFileSync(this.path).toString()) as Block[];
   }
+
   /**
    * Called by Nest as part of app shutdown phase
    * @see https://docs.nestjs.com/fundamentals/lifecycle-events
@@ -58,7 +56,7 @@ export class JsonBlockchainClient
     this.timeouts.forEach(clearTimeout);
   }
 
-  private async simulateAsync<T>(callback: () => T): Promise<T> {
+  private async delay<T>(callback: () => T): Promise<T> {
     return new Promise<T>((resolve) => {
       // Simulate non-deterministic response time
       const timeout = setTimeout(() => {

--- a/src/providers/blockchain/_abstract.ts
+++ b/src/providers/blockchain/_abstract.ts
@@ -4,9 +4,9 @@
  * underlying blockchain.
  */
 export interface BlockchainClient {
-  getChainHeight(): Promise<number>;
+  getBlockCount(): Promise<number>;
   getBlockByHash(hash: string): Promise<Block | undefined>;
-  getBlockByHeight(height: number): Promise<Block | undefined>;
+  getBlocksAtHeight(height: number): Promise<Block[] | undefined>;
 }
 
 export interface Block {

--- a/test/resources/200.json
+++ b/test/resources/200.json
@@ -22879,6 +22879,93 @@
     "nextblockhash": "bf1b004b78938d69ad87de6bef9e5327b0a14a766c5062e47ed9da0c184744fe"
   },
   {
+    "hash": "ef61aaf7f6f742ed825922b10ec504ee74cfcb9c71037706dd8a8FORKEDBLOCK",
+    "confirmations": 5,
+    "strippedsize": 362,
+    "size": 398,
+    "weight": 1484,
+    "height": 198,
+    "masternode": "e86c027861cc0af423313f4152a44a83296a388eb51bf1a6dde9bd75bed55fb4",
+    "minter": "mswsMVsyGMj1FzDMbbxw2QW3KvQAv2FKiy",
+    "mintedBlocks": 198,
+    "stakeModifier": "7d26c199ea71aeb9f751ad826ac0daaf80f56724905f39c4bde1e62da50ccf75",
+    "version": 805306368,
+    "versionHex": "30000000",
+    "merkleroot": "479164663f57dc055dcef234331d8376d0f4dd415494ea0cfb5FORKEDBLOCKTX",
+    "nonutxo": [
+      {
+        "AnchorReward": 0.02,
+        "Burnt": 61.74
+      }
+    ],
+    "tx": [
+      {
+        "txid": "479164663f57dc055dcef234331d8376d0f4dd415494ea0cfb5FORKEDBLOCKTX",
+        "hash": "4fa105e61a96e6a151b7e7cce98a5f67e47a552c9551576c299FORKEDBLOCKTX",
+        "version": 4,
+        "size": 207,
+        "vsize": 180,
+        "weight": 720,
+        "locktime": 0,
+        "vin": [
+          {
+            "coinbase": "02c60000",
+            "sequence": 4294967295
+          }
+        ],
+        "vout": [
+          {
+            "value": 33.33,
+            "n": 0,
+            "scriptPubKey": {
+              "asm": "OP_DUP OP_HASH160 8857c8c3ce618fe7ae5f8ee11ecc8ea421a1d829 OP_EQUALVERIFY OP_CHECKSIG",
+              "hex": "76a9148857c8c3ce618fe7ae5f8ee11ecc8ea421a1d82988ac",
+              "reqSigs": 1,
+              "type": "pubkeyhash",
+              "addresses": [
+                "mswsMVsyGMj1FzDMbbxw2QW3KvQAv2FKiy"
+              ]
+            },
+            "tokenId": 0
+          },
+          {
+            "value": 4.91,
+            "n": 1,
+            "scriptPubKey": {
+              "asm": "OP_HASH160 d33d91b421ec4d8d2af5e94e12ec58ea0009191e OP_EQUAL",
+              "hex": "a914d33d91b421ec4d8d2af5e94e12ec58ea0009191e87",
+              "reqSigs": 1,
+              "type": "scripthash",
+              "addresses": [
+                "2NCWAKfEehP3qibkLKYQjXaWMK23k4EDMVS"
+              ]
+            },
+            "tokenId": 0
+          },
+          {
+            "value": 0,
+            "n": 2,
+            "scriptPubKey": {
+              "asm": "OP_RETURN aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+              "hex": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+              "type": "nulldata"
+            },
+            "tokenId": 0
+          }
+        ],
+        "hex": "040000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0402c60000ffffffff03408ba9c6000000001976a9148857c8c3ce618fe7ae5f8ee11ecc8ea421a1d82988ac00c010441d0000000017a914d33d91b421ec4d8d2af5e94e12ec58ea0009191e87000000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9000120000000000000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "time": 1635739486,
+    "mediantime": 1635739484,
+    "bits": "207fffff",
+    "difficulty": 4.656542373906925e-10,
+    "chainwork": "000000000000000000000000000000000000000000000000000000000000018e",
+    "nTx": 1,
+    "previousblockhash": "30e8c5c67864b83a91223b20b07772f7416e25f5153a1ed0df74fd3bef66cc82",
+    "nextblockhash": "bf1b004b78938d69ad87de6bef9e5327b0a14a766c5062e47ed9da0c184744fe"
+  },
+  {
     "hash": "bf1b004b78938d69ad87de6bef9e5327b0a14a766c5062e47ed9da0c184744fe",
     "confirmations": 4,
     "strippedsize": 362,
@@ -22962,7 +23049,7 @@
     "difficulty": 4.656542373906925e-10,
     "chainwork": "0000000000000000000000000000000000000000000000000000000000000190",
     "nTx": 1,
-    "previousblockhash": "ef61aaf7f6f742ed825922b10ec504ee74cfcb9c71037706dd8a87c627f541f9",
+    "previousblockhash": "ef61aaf7f6f742ed825922b10ec504ee74cfcb9c71037706dd8a8FORKEDBLOCK",
     "nextblockhash": "518cb6bac7530321840eccd9f5c30ab750e78946a1fec0ab44017cbf78f5d8c7"
   }
 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Minor refactoring to BlockchainClient API to more accurately reflect blockchain semantics 
- Add a fork at height `198`
  > The 200.json file now contains an orphaned block: `ef61aaf7f6f742ed825922b10ec504ee74cfcb9c71037706dd8a87c627f541f9`
- Change JsonBlockchainClient to return an array of blocks at a given height (forks can occur at any height, and orphan blocks will not be dropped entirely from the chain)
